### PR TITLE
fix monitor batch size

### DIFF
--- a/src/blob-monitor/monitor.ts
+++ b/src/blob-monitor/monitor.ts
@@ -78,8 +78,7 @@ const processBlockRange = async (
   toBlock: bigint,
   onBlobFound: (blob: ProcessingJob) => Promise<void>
 ): Promise<bigint> => {
-  const configBatchSize = config.batchSize || 10
-  const batchSize = configBatchSize > 5 ? 5 : configBatchSize // Reduce batch size for debugging
+  const batchSize = config.batchSize || 10
   let currentBlock = fromBlock
   let processedCount = 0
   


### PR DESCRIPTION
## Summary
- keep full batch size for block processing

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684366e4dbc083239fc0ff5cc8975b88